### PR TITLE
utils/gnupg: add new package gnupg-utils

### DIFF
--- a/utils/gnupg/Makefile
+++ b/utils/gnupg/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnupg
-PKG_VERSION:=1.4.19
+PKG_VERSION:=1.4.20
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=ftp://ftp.franken.de/pub/crypt/mirror/ftp.gnupg.org/gcrypt/gnupg \
 	ftp://ftp.gnupg.org/gcrypt/gnupg
-PKG_MD5SUM:=3af4ab5b3113b3e28d3551ecf9600785
+PKG_MD5SUM:=b7af897a041c03c8ad1c7c466b54d10d
 
 PKG_LICENSE:=GPL-3.0
 PKG_LICENSE_FILES:=COPYING
@@ -24,12 +24,23 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/gnupg
+define Package/gnupg/Default
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+zlib +libncurses +libreadline
   TITLE:=GNU privacy guard - a free PGP replacement
   URL:=http://www.gnupg.org/
+endef
+
+define Package/gnupg
+  $(call Package/gnupg/Default)
+  MENU:=1
+endef
+
+define Package/gnupg-utils
+  $(call Package/gnupg/Default)
+  DEPENDS:=gnupg
+  TITLE:=Key management utilities for GnuPG
 endef
 
 define Package/gnupg/description
@@ -42,6 +53,11 @@ define Package/gnupg/description
  with PGP2 because it uses IDEA (which is patented worldwide).
 endef
 
+define Package/gnupg-utils/description
+ Key management utilies for GnuPG.
+ This package is needed to import keys from a keyserver.
+endef
+
 CONFIGURE_ARGS += \
 	--disable-rpath \
 	--disable-asm \
@@ -49,9 +65,7 @@ CONFIGURE_ARGS += \
 	--disable-card-support \
 	--disable-agent-support \
 	--disable-bzip2 \
-	--disable-exec \
 	--disable-ldap \
-	--disable-hkp \
 	--disable-finger \
 	--disable-ftp \
 	--disable-dns-srv \
@@ -66,4 +80,13 @@ define Package/gnupg/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gpg $(1)/usr/bin/
 endef
 
+define Package/gnupg-utils/install
+	$(INSTALL_DIR) $(1)/usr/lib/gnupg
+	for file in gpgkeys_curl gpgkeys_hkp; do \
+		$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/lib/gnupg/$$$$file \
+		  $(1)/usr/lib/gnupg/; \
+	done
+endef
+
 $(eval $(call BuildPackage,gnupg))
+$(eval $(call BuildPackage,gnupg-utils))


### PR DESCRIPTION
The current package gnupg does not allow to receive keys due to
disable-exec, disable-hkp configuration.

The patch removes these switches. To avoid unduely increasing the package
size the helper executables are put into a new package gnupg-utils.

The version is bumped to 1.4.20 to avoid an error when receiving keys.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>